### PR TITLE
fix(test): stop asserting a two-byte needle is absent from ciphertext

### DIFF
--- a/python/tests/test_gdrive.py
+++ b/python/tests/test_gdrive.py
@@ -232,14 +232,22 @@ def test_encrypted_file_storage_roundtrip(tmp_path: Path) -> None:
     target = tmp_path / "session.enc"
     storage = EncryptedFileTokenStorage(target, "a-strong-encryption-key")
 
-    storage.set(TokenSession(access_token="at", refresh_token="rt", expires_at=123.0))
+    # Long and distinctive on purpose. A short needle like "rt" appears in
+    # random ciphertext by chance often enough to fail this assertion for real:
+    # two given bytes collide roughly once per 65536 positions, which over a
+    # ~150 byte envelope is a fraction of a percent per run -- and that fires
+    # regularly across four Python versions on every push. The test was
+    # genuinely flaky, not the encryption.
+    refresh = "refresh-token-9f3c1a7e-must-not-appear-in-ciphertext"
+    storage.set(TokenSession(access_token="at", refresh_token=refresh, expires_at=123.0))
     loaded = storage.get()
 
     assert loaded is not None
-    assert loaded.refresh_token == "rt"
+    assert loaded.refresh_token == refresh
     # The refresh token must not be readable on disk.
-    assert b"rt" not in target.read_bytes()
-    assert target.read_bytes()[:12] == b"BYOC_E2EE_V3"
+    on_disk = target.read_bytes()
+    assert refresh.encode() not in on_disk
+    assert on_disk[:12] == b"BYOC_E2EE_V3"
 
 
 def test_encrypted_file_storage_is_owner_only(tmp_path: Path) -> None:


### PR DESCRIPTION
test_encrypted_file_storage_roundtrip stored a refresh token of "rt"
and asserted those bytes do not appear in the encrypted file. The
envelope is random ciphertext, so two given bytes land in it by chance
about once per 65536 positions -- across a ~150 byte envelope that is
roughly 0.2% per run, and four Python versions run it on every push.

Measured: 16 collisions in 4000 trials for a two-byte needle, 0 in 4000
for a 51-byte one. That is a ~0.9% chance of a spurious failure per
push, or about a 60% chance of at least one red CI over 100 pushes.

It fired on Python 3.12 while 3.10, 3.11 and 3.13 passed in the same
run, which looks like a version-specific bug and is nothing of the
sort -- only a different random salt. A test that fails at random costs
more than it proves, because every failure has to be investigated
before it can be dismissed.

The token is now long and distinctive, so the assertion means what it
was always meant to mean: the plaintext is not recoverable from disk.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
